### PR TITLE
Add asynchronous m3u8 parser to check and download missing media segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ python livedumper.py <m3u8_url> --interval <interval> --retries <retries> --wait
 - `--retries`: The number of retry attempts in case of an error. Default is 3.
 - `--wait`: The wait time (in seconds) between retry attempts. Default is 1 second.
 
-The script will create a separate directory named after the m3u8 filename (without extension) and save the downloaded playlists in that directory.
+The script will create a separate directory named after the m3u8 filename (without extension) and save the downloaded playlists in that directory. It will also check for missing media segment files in the same directory and schedule their download if they do not exist.
 
 ## Description
 
 The livedumper script accepts an m3u8 URL as a command-line parameter and downloads the HLS playlist at a configurable interval. Each playlist is stored on the filesystem using a Unix timestamp when the playlist was grabbed. The script also implements a retry mechanism to handle errors when downloading the playlist and logs errors to stdout.
 
-The script creates a separate directory named after the m3u8 filename (without extension) and saves the downloaded playlists in that directory.
+The script creates a separate directory named after the m3u8 filename (without extension) and saves the downloaded playlists in that directory. It also checks for missing media segment files in the same directory and schedules their download if they do not exist.
 
 ## Asynchronous Implementation
 
 The livedumper script now uses `asyncio` for asynchronous programming. The `download_playlist` function is an asynchronous function using `aiohttp` for non-blocking HTTP requests. The `main` function is also an asynchronous function using `asyncio.sleep` for non-blocking sleep intervals. This allows the script to handle multiple tasks concurrently and improve performance.
+
+The script also includes a function `check_and_download_segments` to parse the m3u8 playlist, check for missing media segment files, and schedule their download. This ensures that all media segment files are available in the same directory as the stored playlist file.


### PR DESCRIPTION
Add functionality to check and download missing media segment files in the same directory as the stored playlist file.

* Add `download_segment` function to download missing media segment files.
* Add `check_and_download_segments` function to parse the m3u8 playlist, check for missing media segment files, and schedule their download.
* Modify `main` function to call `check_and_download_segments` after saving the playlist.
* Update `README.md` to include information about checking and downloading missing media segment files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/widgetii/livedumper?shareId=cb44b333-a526-4f8e-a8fd-f7c730ef4188).